### PR TITLE
[visible.directive] Set visible to false only when fully hidden. Fix #19

### DIFF
--- a/src/js/scroll-spy/scroll-container.directive.js
+++ b/src/js/scroll-spy/scroll-container.directive.js
@@ -39,11 +39,19 @@ mod.directive('paScrollContainer', ($window, $timeout, paDebounce) => {
                     };
 
                 selfCtrl.spies.forEach((spy)=> {
-                    let spyRect = spy.getRect();
-                    if ((spyRect.top >= (viewportRect.top - spyRect.height) && (spyRect.top + spyRect.height) <= (viewportRect.top + viewportRect.height)) ||
-                        (spyRect.top < viewportRect.top && (spyRect.height) >= vpHeight)) {
+                    let spyRect = spy.getRect(),
+                        isFullyVisible = (spyRect.top >= viewportRect.top && //Top border in viewport
+                            (spyRect.top + spyRect.height) <= (viewportRect.top + viewportRect.height)) || //Bottom border in viewport
+                            (spyRect.top < viewportRect.top && (spyRect.height) >= vpHeight), // Bigger than viewport
+                        isFullyHidden = !isFullyVisible &&
+                            spyRect.top > (viewportRect.top + viewportRect.height) || //Top border below viewport bottom
+                            (spyRect.top + spyRect.height) < viewportRect.top; //Bottom border above viewport top
+
+
+                    //Only change state when fully visible/hidden
+                    if (isFullyVisible) {
                         spy.setInView(true);
-                    } else {
+                    } else if (isFullyHidden) {
                         spy.setInView(false);
                     }
                 });


### PR DESCRIPTION
I've tried to fix #19 by checking if fully visible/hidden before setting the value.

This has two "issues" I could think of: 
- Inconsistency: the binded variable becomes "true" when it's fully visible, but stays as that untill is fully hidden. That's the desired behavior, but I'm just worried it might somehow lead to confusion
- Impossible to "clear" when there's not enough room for completely hiding the target. This also is not necessarily an issue, and it's a drawback of our decision. (We would have it anyway, even with the previous solution, if the case the page is not big enough to hide the target even partially).

I believe those are not actual issues - but might be worth discuss it/keep track of it
